### PR TITLE
pkg-config

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,25 @@
+on: 
+  - pull_request
+  - push
+
+jobs:
+  nix:
+    name: Nixpkgs
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - uses: cachix/install-nix-action@v20
+    - run: |
+        nix flake check -L
+  ubuntu:
+    name: Ubuntu
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - uses: haskell/actions/setup@v2
+      with:
+        ghc-version: "9.4"
+        cabal-version: "latest"
+    - run: DEBIAN_FRONTEND=noninteractive sudo apt update && sudo apt install -y libopenmpi-dev libopenmpi3 openmpi-bin
+    - run: cabal build
+    - run: cabal test

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 # Stack uses this directory as scratch space.
 /.stack-work/
+.direnv/
+dist-newstyle/
+result*/

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -4,7 +4,7 @@ pool:
 steps:
 - script: |
     sudo apt-get update
-    sudo apt-get install --yes --no-install-recommends libmpich-dev mpich
+    sudo apt-get install --yes --no-install-recommends libmpich-dev mpich libopenmpi-dev openmpi
   displayName: Install system packages
 - script: |
     mkdir -p "$HOME/.local/bin"

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,60 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1692799911,
+        "narHash": "sha256-3eihraek4qL744EvQXsK1Ha6C3CR7nnT8X2qWap4RNk=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "f9e7cf818399d17d347f847525c5a5a8032e4e44",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1694343207,
+        "narHash": "sha256-jWi7OwFxU5Owi4k2JmiL1sa/OuBCQtpaAesuj5LXC8w=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "78058d810644f5ed276804ce7ea9e82d92bee293",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "ref": "nixpkgs-unstable",
+        "type": "indirect"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,57 @@
+{
+  description = "MPI bindings for Haskell";
+
+  inputs = {
+    nixpkgs.url = "nixpkgs/nixpkgs-unstable";
+
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  nixConfig = {
+    allow-import-from-derivation = "true";
+  };
+
+  outputs = { self, nixpkgs, flake-utils }: flake-utils.lib.eachSystem [ "x86_64-linux" ]
+    (system:
+      let
+        pkgs = import nixpkgs {
+          inherit system;
+          #config.allowUnsupportedSystem = true;
+          overlays = [ (import ./nix/overlay.nix) ];
+        };
+      in
+      {
+        packages = {
+          default = self.packages."${system}".mpi-hs_lmpi;
+          mpi-hs_openmpi = pkgs.haskell.lib.appendConfigureFlags (pkgs.haskellPackages.mpi-hs.override { mpi = pkgs.mpi; }) [ "-fopenmpi" "-f-mpich" "-f-mvapich" ];
+          mpi-hs_mpich = pkgs.haskell.lib.appendConfigureFlags (pkgs.haskellPackages.mpi-hs.override { mpi = pkgs.mpich; }) [ "-fmpich" "-f-openmpi" "-f-mvapich" ];
+          mpi-hs_mvapich = pkgs.haskell.lib.appendConfigureFlags (pkgs.haskellPackages.mpi-hs.override { mpi = pkgs.mvapich; }) [ "-fmvapich" "-f-openmpi" "-f-mpich" ];
+          mpi-hs_lmpi = pkgs.haskell.lib.appendConfigureFlags (pkgs.haskellPackages.mpi-hs.override { mpi = pkgs.mpi; }) [ "-f-mvapich" "-f-openmpi" "-f-mpich" ];
+        };
+
+        devShells.default = pkgs.haskellPackages.shellFor {
+          withHoogle = true;
+          packages = p: [ p.mpi-hs ];
+          buildInputs = with pkgs; [
+            cabal-install
+            cabal2nix
+            haskell-language-server
+            haskellPackages.hls-fourmolu-plugin
+            haskellPackages.fourmolu
+            hlint
+            hpack
+            nixpkgs-fmt
+            pkg-config
+            mpi
+            mvapich
+            mpich
+          ];
+        };
+
+        formatter = pkgs.nixpkgs-fmt;
+      }) // {
+    overlays.default = import ./nix/overlay.nix;
+
+    checks.x86_64-linux = self.packages.x86_64-linux;
+  };
+}

--- a/mpi-hs.cabal
+++ b/mpi-hs.cabal
@@ -1,13 +1,11 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.33.0.
+-- This file has been generated from package.yaml by hpack version 0.35.2.
 --
 -- see: https://github.com/sol/hpack
---
--- hash: 40051a2fa5a9acbb76076a5a8a95aef681997552d679994fcbe1d8b29474caaf
 
 name:           mpi-hs
-version:        0.7.1.2
+version:        0.7.2.0
 synopsis:       MPI bindings for Haskell
 description:    MPI (the [Message Passinag Interface](https://www.mpi-forum.org)) is
                 a widely used standard for distributed-memory programming on HPC
@@ -59,38 +57,18 @@ source-repository head
   type: git
   location: https://github.com/eschnett/mpi-hs
 
-flag mpich-debian
-  description: Use MPICH on Debian
+flag mpich
+  description: Use MPICH
   manual: True
   default: False
 
-flag mpich-macports
-  description: Use MPICH on MacPorts
+flag mvapich
+  description: Use MVAPICH2
   manual: True
   default: False
 
-flag mpich-ubuntu
-  description: Use MPICH on Ubuntu
-  manual: True
-  default: False
-
-flag openmpi-debian
-  description: Use OpenMPI on Debian
-  manual: True
-  default: False
-
-flag openmpi-macports
-  description: Use OpenMPI on MacPorts
-  manual: True
-  default: False
-
-flag openmpi-ubuntu
-  description: Use OpenMPI on Ubuntu
-  manual: True
-  default: False
-
-flag system-mpi
-  description: Use generic system MPI
+flag openmpi
+  description: Use OpenMPI
   manual: True
   default: True
 
@@ -110,71 +88,28 @@ library
   build-tools:
       c2hs
   build-depends:
-      base >=4 && <5
+      base ==4.*
     , bytestring
     , monad-loops
-  if flag(mpich-debian)
-    include-dirs:
-        /usr/include/mpich
-        /usr/include/x86_64-linux-gnu/mpich
-    extra-lib-dirs:
-        /usr/lib/x86_64-linux-gnu
-        /usr/lib/x86_64-linux-gnu/lib
-    extra-libraries:
-        mpich
-  if flag(mpich-macports)
-    include-dirs:
-        /opt/local/include/mpich-mp
-    extra-lib-dirs:
-        /opt/local/lib/mpich-mp
-    extra-libraries:
-        mpi
-  if flag(mpich-ubuntu)
-    include-dirs:
-        /usr/include/x86_64-linux-gnu/mpich
-        /usr/lib/mpich/include
-    extra-lib-dirs:
-        /usr/lib/mpich/lib
-        /usr/lib/x86_64-linux-gnu
-    extra-libraries:
-        mpich
-  if flag(openmpi-debian)
-    include-dirs:
-        /usr/lib/x86_64-linux-gnu/openmpi/include
-    extra-lib-dirs:
-        /usr/lib/x86_64-linux-gnu/openmpi/lib
-    extra-libraries:
-        mpi
-  if flag(openmpi-macports)
-    include-dirs:
-        /opt/local/include/openmpi-mp
-    extra-lib-dirs:
-        /opt/local/lib/openmpi-mp
-    extra-libraries:
-        mpi
-  if flag(openmpi-ubuntu)
-    include-dirs:
-        /usr/lib/openmpi/include
-    extra-lib-dirs:
-        /usr/lib/openmpi/lib
-    extra-libraries:
-        mpi
-  if flag(system-mpi)
-    if !flag(mpich-debian)
-      if !flag(mpich-macports)
-        if !flag(mpich-ubuntu)
-          if !flag(openmpi-debian)
-            if !flag(openmpi-macports)
-              if !flag(openmpi-ubuntu)
-                include-dirs:
-                    /usr/include/mpich
-                    /usr/include/x86_64-linux-gnu/mpich
-                extra-lib-dirs:
-                    /usr/lib/x86_64-linux-gnu
-                    /usr/lib/x86_64-linux-gnu/lib
-                extra-libraries:
-                    mpich
   default-language: Haskell2010
+  if flag(mpich) && !flag(openmpi) && !flag(mvapich)
+    pkgconfig-depends:
+        mpich
+  else
+    extra-libraries:
+        mpi
+  if flag(openmpi) && !flag(mpich) && !flag(mvapich)
+    pkgconfig-depends:
+        ompi
+  else
+    extra-libraries:
+        mpi
+  if flag(mvapich) && !flag(mpich) && !flag(openmpi)
+    pkgconfig-depends:
+        mvapich2
+  else
+    extra-libraries:
+        mpi
 
 executable example1
   main-is: example1.hs
@@ -186,68 +121,25 @@ executable example1
   build-depends:
       base
     , mpi-hs
-  if flag(mpich-debian)
-    include-dirs:
-        /usr/include/mpich
-        /usr/include/x86_64-linux-gnu/mpich
-    extra-lib-dirs:
-        /usr/lib/x86_64-linux-gnu
-        /usr/lib/x86_64-linux-gnu/lib
-    extra-libraries:
-        mpich
-  if flag(mpich-macports)
-    include-dirs:
-        /opt/local/include/mpich-mp
-    extra-lib-dirs:
-        /opt/local/lib/mpich-mp
-    extra-libraries:
-        mpi
-  if flag(mpich-ubuntu)
-    include-dirs:
-        /usr/include/x86_64-linux-gnu/mpich
-        /usr/lib/mpich/include
-    extra-lib-dirs:
-        /usr/lib/mpich/lib
-        /usr/lib/x86_64-linux-gnu
-    extra-libraries:
-        mpich
-  if flag(openmpi-debian)
-    include-dirs:
-        /usr/lib/x86_64-linux-gnu/openmpi/include
-    extra-lib-dirs:
-        /usr/lib/x86_64-linux-gnu/openmpi/lib
-    extra-libraries:
-        mpi
-  if flag(openmpi-macports)
-    include-dirs:
-        /opt/local/include/openmpi-mp
-    extra-lib-dirs:
-        /opt/local/lib/openmpi-mp
-    extra-libraries:
-        mpi
-  if flag(openmpi-ubuntu)
-    include-dirs:
-        /usr/lib/openmpi/include
-    extra-lib-dirs:
-        /usr/lib/openmpi/lib
-    extra-libraries:
-        mpi
-  if flag(system-mpi)
-    if !flag(mpich-debian)
-      if !flag(mpich-macports)
-        if !flag(mpich-ubuntu)
-          if !flag(openmpi-debian)
-            if !flag(openmpi-macports)
-              if !flag(openmpi-ubuntu)
-                include-dirs:
-                    /usr/include/mpich
-                    /usr/include/x86_64-linux-gnu/mpich
-                extra-lib-dirs:
-                    /usr/lib/x86_64-linux-gnu
-                    /usr/lib/x86_64-linux-gnu/lib
-                extra-libraries:
-                    mpich
   default-language: Haskell2010
+  if flag(mpich) && !flag(openmpi) && !flag(mvapich)
+    pkgconfig-depends:
+        mpich
+  else
+    extra-libraries:
+        mpi
+  if flag(openmpi) && !flag(mpich) && !flag(mvapich)
+    pkgconfig-depends:
+        ompi
+  else
+    extra-libraries:
+        mpi
+  if flag(mvapich) && !flag(mpich) && !flag(openmpi)
+    pkgconfig-depends:
+        mvapich2
+  else
+    extra-libraries:
+        mpi
 
 executable example2
   main-is: example2.hs
@@ -259,68 +151,25 @@ executable example2
   build-depends:
       base
     , mpi-hs
-  if flag(mpich-debian)
-    include-dirs:
-        /usr/include/mpich
-        /usr/include/x86_64-linux-gnu/mpich
-    extra-lib-dirs:
-        /usr/lib/x86_64-linux-gnu
-        /usr/lib/x86_64-linux-gnu/lib
-    extra-libraries:
-        mpich
-  if flag(mpich-macports)
-    include-dirs:
-        /opt/local/include/mpich-mp
-    extra-lib-dirs:
-        /opt/local/lib/mpich-mp
-    extra-libraries:
-        mpi
-  if flag(mpich-ubuntu)
-    include-dirs:
-        /usr/include/x86_64-linux-gnu/mpich
-        /usr/lib/mpich/include
-    extra-lib-dirs:
-        /usr/lib/mpich/lib
-        /usr/lib/x86_64-linux-gnu
-    extra-libraries:
-        mpich
-  if flag(openmpi-debian)
-    include-dirs:
-        /usr/lib/x86_64-linux-gnu/openmpi/include
-    extra-lib-dirs:
-        /usr/lib/x86_64-linux-gnu/openmpi/lib
-    extra-libraries:
-        mpi
-  if flag(openmpi-macports)
-    include-dirs:
-        /opt/local/include/openmpi-mp
-    extra-lib-dirs:
-        /opt/local/lib/openmpi-mp
-    extra-libraries:
-        mpi
-  if flag(openmpi-ubuntu)
-    include-dirs:
-        /usr/lib/openmpi/include
-    extra-lib-dirs:
-        /usr/lib/openmpi/lib
-    extra-libraries:
-        mpi
-  if flag(system-mpi)
-    if !flag(mpich-debian)
-      if !flag(mpich-macports)
-        if !flag(mpich-ubuntu)
-          if !flag(openmpi-debian)
-            if !flag(openmpi-macports)
-              if !flag(openmpi-ubuntu)
-                include-dirs:
-                    /usr/include/mpich
-                    /usr/include/x86_64-linux-gnu/mpich
-                extra-lib-dirs:
-                    /usr/lib/x86_64-linux-gnu
-                    /usr/lib/x86_64-linux-gnu/lib
-                extra-libraries:
-                    mpich
   default-language: Haskell2010
+  if flag(mpich) && !flag(openmpi) && !flag(mvapich)
+    pkgconfig-depends:
+        mpich
+  else
+    extra-libraries:
+        mpi
+  if flag(openmpi) && !flag(mpich) && !flag(mvapich)
+    pkgconfig-depends:
+        ompi
+  else
+    extra-libraries:
+        mpi
+  if flag(mvapich) && !flag(mpich) && !flag(openmpi)
+    pkgconfig-depends:
+        mvapich2
+  else
+    extra-libraries:
+        mpi
 
 executable version
   main-is: version.hs
@@ -332,68 +181,25 @@ executable version
   build-depends:
       base
     , mpi-hs
-  if flag(mpich-debian)
-    include-dirs:
-        /usr/include/mpich
-        /usr/include/x86_64-linux-gnu/mpich
-    extra-lib-dirs:
-        /usr/lib/x86_64-linux-gnu
-        /usr/lib/x86_64-linux-gnu/lib
-    extra-libraries:
-        mpich
-  if flag(mpich-macports)
-    include-dirs:
-        /opt/local/include/mpich-mp
-    extra-lib-dirs:
-        /opt/local/lib/mpich-mp
-    extra-libraries:
-        mpi
-  if flag(mpich-ubuntu)
-    include-dirs:
-        /usr/include/x86_64-linux-gnu/mpich
-        /usr/lib/mpich/include
-    extra-lib-dirs:
-        /usr/lib/mpich/lib
-        /usr/lib/x86_64-linux-gnu
-    extra-libraries:
-        mpich
-  if flag(openmpi-debian)
-    include-dirs:
-        /usr/lib/x86_64-linux-gnu/openmpi/include
-    extra-lib-dirs:
-        /usr/lib/x86_64-linux-gnu/openmpi/lib
-    extra-libraries:
-        mpi
-  if flag(openmpi-macports)
-    include-dirs:
-        /opt/local/include/openmpi-mp
-    extra-lib-dirs:
-        /opt/local/lib/openmpi-mp
-    extra-libraries:
-        mpi
-  if flag(openmpi-ubuntu)
-    include-dirs:
-        /usr/lib/openmpi/include
-    extra-lib-dirs:
-        /usr/lib/openmpi/lib
-    extra-libraries:
-        mpi
-  if flag(system-mpi)
-    if !flag(mpich-debian)
-      if !flag(mpich-macports)
-        if !flag(mpich-ubuntu)
-          if !flag(openmpi-debian)
-            if !flag(openmpi-macports)
-              if !flag(openmpi-ubuntu)
-                include-dirs:
-                    /usr/include/mpich
-                    /usr/include/x86_64-linux-gnu/mpich
-                extra-lib-dirs:
-                    /usr/lib/x86_64-linux-gnu
-                    /usr/lib/x86_64-linux-gnu/lib
-                extra-libraries:
-                    mpich
   default-language: Haskell2010
+  if flag(mpich) && !flag(openmpi) && !flag(mvapich)
+    pkgconfig-depends:
+        mpich
+  else
+    extra-libraries:
+        mpi
+  if flag(openmpi) && !flag(mpich) && !flag(mvapich)
+    pkgconfig-depends:
+        ompi
+  else
+    extra-libraries:
+        mpi
+  if flag(mvapich) && !flag(mpich) && !flag(openmpi)
+    pkgconfig-depends:
+        mvapich2
+  else
+    extra-libraries:
+        mpi
 
 test-suite mpi-test
   type: exitcode-stdio-1.0
@@ -407,68 +213,25 @@ test-suite mpi-test
       base
     , monad-loops
     , mpi-hs
-  if flag(mpich-debian)
-    include-dirs:
-        /usr/include/mpich
-        /usr/include/x86_64-linux-gnu/mpich
-    extra-lib-dirs:
-        /usr/lib/x86_64-linux-gnu
-        /usr/lib/x86_64-linux-gnu/lib
-    extra-libraries:
-        mpich
-  if flag(mpich-macports)
-    include-dirs:
-        /opt/local/include/mpich-mp
-    extra-lib-dirs:
-        /opt/local/lib/mpich-mp
-    extra-libraries:
-        mpi
-  if flag(mpich-ubuntu)
-    include-dirs:
-        /usr/include/x86_64-linux-gnu/mpich
-        /usr/lib/mpich/include
-    extra-lib-dirs:
-        /usr/lib/mpich/lib
-        /usr/lib/x86_64-linux-gnu
-    extra-libraries:
-        mpich
-  if flag(openmpi-debian)
-    include-dirs:
-        /usr/lib/x86_64-linux-gnu/openmpi/include
-    extra-lib-dirs:
-        /usr/lib/x86_64-linux-gnu/openmpi/lib
-    extra-libraries:
-        mpi
-  if flag(openmpi-macports)
-    include-dirs:
-        /opt/local/include/openmpi-mp
-    extra-lib-dirs:
-        /opt/local/lib/openmpi-mp
-    extra-libraries:
-        mpi
-  if flag(openmpi-ubuntu)
-    include-dirs:
-        /usr/lib/openmpi/include
-    extra-lib-dirs:
-        /usr/lib/openmpi/lib
-    extra-libraries:
-        mpi
-  if flag(system-mpi)
-    if !flag(mpich-debian)
-      if !flag(mpich-macports)
-        if !flag(mpich-ubuntu)
-          if !flag(openmpi-debian)
-            if !flag(openmpi-macports)
-              if !flag(openmpi-ubuntu)
-                include-dirs:
-                    /usr/include/mpich
-                    /usr/include/x86_64-linux-gnu/mpich
-                extra-lib-dirs:
-                    /usr/lib/x86_64-linux-gnu
-                    /usr/lib/x86_64-linux-gnu/lib
-                extra-libraries:
-                    mpich
   default-language: Haskell2010
+  if flag(mpich) && !flag(openmpi) && !flag(mvapich)
+    pkgconfig-depends:
+        mpich
+  else
+    extra-libraries:
+        mpi
+  if flag(openmpi) && !flag(mpich) && !flag(mvapich)
+    pkgconfig-depends:
+        ompi
+  else
+    extra-libraries:
+        mpi
+  if flag(mvapich) && !flag(mpich) && !flag(openmpi)
+    pkgconfig-depends:
+        mvapich2
+  else
+    extra-libraries:
+        mpi
 
 test-suite mpi-test-storable
   type: exitcode-stdio-1.0
@@ -481,65 +244,22 @@ test-suite mpi-test-storable
   build-depends:
       base
     , mpi-hs
-  if flag(mpich-debian)
-    include-dirs:
-        /usr/include/mpich
-        /usr/include/x86_64-linux-gnu/mpich
-    extra-lib-dirs:
-        /usr/lib/x86_64-linux-gnu
-        /usr/lib/x86_64-linux-gnu/lib
-    extra-libraries:
-        mpich
-  if flag(mpich-macports)
-    include-dirs:
-        /opt/local/include/mpich-mp
-    extra-lib-dirs:
-        /opt/local/lib/mpich-mp
-    extra-libraries:
-        mpi
-  if flag(mpich-ubuntu)
-    include-dirs:
-        /usr/include/x86_64-linux-gnu/mpich
-        /usr/lib/mpich/include
-    extra-lib-dirs:
-        /usr/lib/mpich/lib
-        /usr/lib/x86_64-linux-gnu
-    extra-libraries:
-        mpich
-  if flag(openmpi-debian)
-    include-dirs:
-        /usr/lib/x86_64-linux-gnu/openmpi/include
-    extra-lib-dirs:
-        /usr/lib/x86_64-linux-gnu/openmpi/lib
-    extra-libraries:
-        mpi
-  if flag(openmpi-macports)
-    include-dirs:
-        /opt/local/include/openmpi-mp
-    extra-lib-dirs:
-        /opt/local/lib/openmpi-mp
-    extra-libraries:
-        mpi
-  if flag(openmpi-ubuntu)
-    include-dirs:
-        /usr/lib/openmpi/include
-    extra-lib-dirs:
-        /usr/lib/openmpi/lib
-    extra-libraries:
-        mpi
-  if flag(system-mpi)
-    if !flag(mpich-debian)
-      if !flag(mpich-macports)
-        if !flag(mpich-ubuntu)
-          if !flag(openmpi-debian)
-            if !flag(openmpi-macports)
-              if !flag(openmpi-ubuntu)
-                include-dirs:
-                    /usr/include/mpich
-                    /usr/include/x86_64-linux-gnu/mpich
-                extra-lib-dirs:
-                    /usr/lib/x86_64-linux-gnu
-                    /usr/lib/x86_64-linux-gnu/lib
-                extra-libraries:
-                    mpich
   default-language: Haskell2010
+  if flag(mpich) && !flag(openmpi) && !flag(mvapich)
+    pkgconfig-depends:
+        mpich
+  else
+    extra-libraries:
+        mpi
+  if flag(openmpi) && !flag(mpich) && !flag(mvapich)
+    pkgconfig-depends:
+        ompi
+  else
+    extra-libraries:
+        mpi
+  if flag(mvapich) && !flag(mpich) && !flag(openmpi)
+    pkgconfig-depends:
+        mvapich2
+  else
+    extra-libraries:
+        mpi

--- a/nix/mpi-hs.nix
+++ b/nix/mpi-hs.nix
@@ -1,0 +1,29 @@
+{ mkDerivation
+, pkg-config
+, base
+, bytestring
+, c2hs
+, lib
+, monad-loops
+, mpi
+, mpiCheckPhaseHook
+, openssh
+}:
+mkDerivation {
+  pname = "mpi-hs";
+  version = "0.7.2.0";
+  src = lib.cleanSource ./..;
+  isLibrary = true;
+  isExecutable = true;
+  buildTools = [ pkg-config ];
+  pkg-configDepends = [ mpi ];
+  libraryHaskellDepends = [ base bytestring monad-loops ];
+  libraryToolDepends = [ c2hs ];
+  executableHaskellDepends = [ base ];
+  executableSystemDepends = [ mpi ];
+  testHaskellDepends = [ base monad-loops ];
+  testSystemDepends = [ openssh mpi mpiCheckPhaseHook] ;
+  homepage = "https://github.com/eschnett/mpi-hs#readme";
+  description = "MPI bindings for Haskell";
+  license = lib.licenses.asl20;
+}

--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -1,0 +1,16 @@
+final: prev:
+
+let
+  haskellOverrides = hfinal: hprev: {
+    mpi-hs = hfinal.callPackage ./mpi-hs.nix { };
+  };
+in
+{
+  haskell = prev.haskell // {
+    packages = prev.haskell.packages // (builtins.mapAttrs
+      (key: val: val.override { overrides = haskellOverrides; })
+      prev.haskell.packages
+    );
+  };
+}
+

--- a/package.yaml
+++ b/package.yaml
@@ -38,32 +38,16 @@ description: |
   is an error in this package.
 
 flags:
-  mpich-debian:
-    description: Use MPICH on Debian
+  mpich:
+    description: Use MPICH
     manual: true
     default: false
-  mpich-macports:
-    description: Use MPICH on MacPorts
+  mvapich:
+    description: Use MVAPICH2
     manual: true
     default: false
-  mpich-ubuntu:
-    description: Use MPICH on Ubuntu
-    manual: true
-    default: false
-  openmpi-debian:
-    description: Use OpenMPI on Debian
-    manual: true
-    default: false
-  openmpi-macports:
-    description: Use OpenMPI on MacPorts
-    manual: true
-    default: false
-  openmpi-ubuntu:
-    description: Use OpenMPI on Ubuntu
-    manual: true
-    default: false
-  system-mpi:
-    description: Use generic system MPI
+  openmpi:
+    description: Use OpenMPI
     manual: true
     default: true
 
@@ -93,73 +77,28 @@ library:
     - c/include
 
 when:
-  - condition: flag(mpich-debian)
-    include-dirs:
-      - /usr/include/mpich
-      - /usr/include/x86_64-linux-gnu/mpich
-    extra-lib-dirs:
-      - /usr/lib/x86_64-linux-gnu
-      - /usr/lib/x86_64-linux-gnu/lib
-    extra-libraries:
-      - mpich
-  - condition: flag(mpich-macports)
-    include-dirs:
-      - /opt/local/include/mpich-mp
-    extra-lib-dirs:
-      - /opt/local/lib/mpich-mp
-    extra-libraries:
-      - mpi
-  - condition: flag(mpich-ubuntu)
-    include-dirs:
-      - /usr/include/x86_64-linux-gnu/mpich
-      - /usr/lib/mpich/include
-    extra-lib-dirs:
-      - /usr/lib/mpich/lib
-      - /usr/lib/x86_64-linux-gnu
-    extra-libraries:
-      - mpich
-  - condition: flag(openmpi-debian)
-    include-dirs:
-      - /usr/lib/x86_64-linux-gnu/openmpi/include
-    extra-lib-dirs:
-      - /usr/lib/x86_64-linux-gnu/openmpi/lib
-    extra-libraries:
-      - mpi
-  - condition: flag(openmpi-macports)
-    include-dirs:
-      - /opt/local/include/openmpi-mp
-    extra-lib-dirs:
-      - /opt/local/lib/openmpi-mp
-    extra-libraries:
-      - mpi
-  - condition: flag(openmpi-ubuntu)
-    include-dirs:
-      - /usr/lib/openmpi/include
-    extra-lib-dirs:
-      - /usr/lib/openmpi/lib
-    extra-libraries:
-      - mpi
-  - condition: flag(system-mpi)
-    when:
-      - condition: '!flag(mpich-debian)'
-        when:
-          - condition: '!flag(mpich-macports)'
-            when:
-              - condition: '!flag(mpich-ubuntu)'
-                when:
-                  - condition: '!flag(openmpi-debian)'
-                    when:
-                      - condition: '!flag(openmpi-macports)'
-                        when:
-                          - condition: '!flag(openmpi-ubuntu)'
-                            include-dirs:
-                              - /usr/include/mpich
-                              - /usr/include/x86_64-linux-gnu/mpich
-                            extra-lib-dirs:
-                              - /usr/lib/x86_64-linux-gnu
-                              - /usr/lib/x86_64-linux-gnu/lib
-                            extra-libraries:
-                              - mpich
+  - condition: flag(mpich) && !flag(openmpi) && !flag(mvapich)
+    then:
+      pkg-config-dependencies:
+        - mpich
+    else:
+      extra-libraries:
+        - mpi
+  - condition: flag(openmpi) && !flag(mpich) && !flag(mvapich)
+    then:
+      pkg-config-dependencies:
+        - ompi
+    else:
+      extra-libraries:
+        - mpi
+  - condition: flag(mvapich) && !flag(mpich) && !flag(openmpi)
+    then:
+      pkg-config-dependencies:
+        - mvapich2
+    else:
+      extra-libraries:
+        - mpi
+  
 
 executables:
   version:

--- a/stack.yaml
+++ b/stack.yaml
@@ -2,8 +2,9 @@
 # resolver: lts-14.27
 # resolver: lts-15.3
 # resolver: lts-15.16
+# resolver: lts-16.3
 resolver: lts-16.3
-# resolver: nightly-2020-06-29
+# resolver: nightly-2020-06-29.
 
 # User packages to be built.
 packages:

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -6,7 +6,7 @@
 packages: []
 snapshots:
 - completed:
-    size: 503821
-    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/nightly/2020/6/29.yaml
-    sha256: e1bb5560cc1143c2eb3ece3ee90807d812d7fd94742fc9b9de016e717b531c32
-  original: nightly-2020-06-29
+    sha256: 65e3a94c65ad07fa1913649e3f1e36c4af51bf528a5d9fd217bdc1b46d0477cc
+    size: 531696
+    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/16/3.yaml
+  original: lts-16.3


### PR DESCRIPTION
I've changed the cabal setup to use MPI's package config support. I've tested with all three (OpenMPI, MVAPICH2, MPICH) implementations and so far it seems to work flawlessly. The advantage is, that we can avoid hardcoded paths and unbreak strange linking in nixpkgs with this setup, besides generally more flexibility.