### PR TITLE
Support for MVAPICH >= 3

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    - uses: cachix/install-nix-action@v20
+    - uses: cachix/install-nix-action@v31
     - run: |
         nix flake check -L
   ubuntu:
@@ -18,7 +18,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: haskell/actions/setup@v2
       with:
-        ghc-version: "9.4"
+        ghc-version: "9.10"
         cabal-version: "latest"
     - run: DEBIAN_FRONTEND=noninteractive sudo apt update && sudo apt install -y libopenmpi-dev libopenmpi3 openmpi-bin
     - run: cabal build

--- a/README.md
+++ b/README.md
@@ -114,8 +114,8 @@ instructions.
 - MVAPICH via the `-fmvapich -f-openmpi` cabal flags
 - MPICH via the `-fmpich -f-openmpi` cabal flags
 
-Alternatively, `mpi-hs` can link against `-lmpi` an `mpi.h` generically, if all
-pkg-config options are disabled via `-f-openmpi -f-mpich -f-mvapich`.
+Alternatively, `mpi-hs` can link against `-lmpi` and `mpi.h` generically, if all
+pkg-config options are disabled via `-f-openmpi -f-mpich -f-mvapich -f-mvapich3`.
 In this case you may need to specify `--extra-include-dirs` and `--extra-lib-dirs`
 and point them to your MPI installation directory.
 

--- a/flake.lock
+++ b/flake.lock
@@ -5,11 +5,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1705309234,
-        "narHash": "sha256-uNRRNRKmJyCRC/8y1RqBkqWBLM034y4qN7EprSdmgyA=",
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "1ef2e671c3b0c19053962c07dbda38332dcebf26",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
         "type": "github"
       },
       "original": {
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1706683685,
-        "narHash": "sha256-FtPPshEpxH/ewBOsdKBNhlsL2MLEFv1hEnQ19f/bFsQ=",
+        "lastModified": 1768783163,
+        "narHash": "sha256-tLj4KcRDLakrlpvboTJDKsrp6z2XLwyQ4Zmo+w8KsY4=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "5ad9903c16126a7d949101687af0aa589b1d7d3d",
+        "rev": "bde09022887110deb780067364a0818e89258968",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -32,7 +32,7 @@
             cabal-install
             cabal2nix
             haskell-language-server
-            haskellPackages.hls-fourmolu-plugin
+            # haskellPackages.hls-fourmolu-plugin
             haskellPackages.fourmolu
             hlint
             hpack

--- a/mpi-hs.cabal
+++ b/mpi-hs.cabal
@@ -1,6 +1,6 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.35.2.
+-- This file has been generated from package.yaml by hpack version 0.38.3.
 --
 -- see: https://github.com/sol/hpack
 
@@ -40,7 +40,7 @@ homepage:       https://github.com/eschnett/mpi-hs#readme
 bug-reports:    https://github.com/eschnett/mpi-hs/issues
 author:         Erik Schnetter <schnetter@gmail.com>
 maintainer:     Erik Schnetter <schnetter@gmail.com>, Phillip Seeber <phillip.seeber@googlemail.com>
-copyright:      2018, 2019, 2020, 2023, 2024 Erik Schnetter <schnetter@gmail.com>, 2024 Phillip Seeber Phillip Seeber <phillip.seeber@googlemail.com>
+copyright:      2018, 2019, 2020, 2023, 2024, 2025, 2026 Erik Schnetter <schnetter@gmail.com>, 2024, 2025, 2026 Phillip Seeber <phillip.seeber@googlemail.com>
 license:        Apache-2.0
 license-file:   LICENSE
 build-type:     Simple
@@ -63,7 +63,7 @@ flag mpich
   default: False
 
 flag mvapich
-  description: Use MVAPICH2
+  description: Use MVAPICH
   manual: True
   default: False
 
@@ -100,7 +100,7 @@ library
         ompi
   if flag(mvapich)
     pkgconfig-depends:
-        mvapich2
+        mvapich
   if !flag(mvapich) && !flag(mpich) && !flag(openmpi)
     extra-libraries:
         mpi
@@ -124,7 +124,7 @@ executable example1
         ompi
   if flag(mvapich)
     pkgconfig-depends:
-        mvapich2
+        mvapich
   if !flag(mvapich) && !flag(mpich) && !flag(openmpi)
     extra-libraries:
         mpi
@@ -148,7 +148,7 @@ executable example2
         ompi
   if flag(mvapich)
     pkgconfig-depends:
-        mvapich2
+        mvapich
   if !flag(mvapich) && !flag(mpich) && !flag(openmpi)
     extra-libraries:
         mpi
@@ -172,7 +172,7 @@ executable version
         ompi
   if flag(mvapich)
     pkgconfig-depends:
-        mvapich2
+        mvapich
   if !flag(mvapich) && !flag(mpich) && !flag(openmpi)
     extra-libraries:
         mpi
@@ -198,7 +198,7 @@ test-suite mpi-test
         ompi
   if flag(mvapich)
     pkgconfig-depends:
-        mvapich2
+        mvapich
   if !flag(mvapich) && !flag(mpich) && !flag(openmpi)
     extra-libraries:
         mpi
@@ -223,7 +223,7 @@ test-suite mpi-test-storable
         ompi
   if flag(mvapich)
     pkgconfig-depends:
-        mvapich2
+        mvapich
   if !flag(mvapich) && !flag(mpich) && !flag(openmpi)
     extra-libraries:
         mpi

--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -27,7 +27,7 @@ in
         mpi-hs_mvapich =
           addMpiHsTestDeps
             (hfinal.callCabal2nixWithOptions "mpi-hs" ../. "-f-openmpi -f-mpich -fmvapich" {
-              mvapich2 = final.mvapich;
+              mvapich = final.mvapich;
             });
 
         mpi-hs_mpi =

--- a/package.yaml
+++ b/package.yaml
@@ -4,7 +4,7 @@ github: "eschnett/mpi-hs"
 license: Apache-2.0
 author: "Erik Schnetter <schnetter@gmail.com>"
 maintainer: "Erik Schnetter <schnetter@gmail.com>, Phillip Seeber <phillip.seeber@googlemail.com>"
-copyright: "2018, 2019, 2020, 2023, 2024 Erik Schnetter <schnetter@gmail.com>, 2024 Phillip Seeber Phillip Seeber <phillip.seeber@googlemail.com>"
+copyright: "2018, 2019, 2020, 2023, 2024, 2025, 2026 Erik Schnetter <schnetter@gmail.com>, 2024, 2025, 2026 Phillip Seeber <phillip.seeber@googlemail.com>"
 category: Distributed Computing
 synopsis: MPI bindings for Haskell
 description: |
@@ -43,7 +43,7 @@ flags:
     manual: true
     default: false
   mvapich:
-    description: Use MVAPICH2
+    description: Use MVAPICH
     manual: true
     default: false
   openmpi:
@@ -85,7 +85,7 @@ when:
       - ompi
   - condition: "flag(mvapich)"
     pkg-config-dependencies:
-      - mvapich2
+      - mvapich
   - condition: "!flag(mvapich) && !flag(mpich) && !flag(openmpi)"
     extra-libraries:
       - mpi


### PR DESCRIPTION
Adds another cabal flag for MVAPICH3 support. In MVAPICH3 the pkg-config name was changed from `mvapich2` to merely `mvapich`, so not both versions can simultaenously be handled by the same flag.

TODO:
  * [ ] Wait for https://github.com/NixOS/nixpkgs/pull/293499 to be merged and update the Nix flake to have MVAPICH3 in the Nix build