### PR TITLE
Gatherv

### DIFF
--- a/mpi-hs.cabal
+++ b/mpi-hs.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:           mpi-hs
-version:        0.7.3.0
+version:        0.7.3.1
 synopsis:       MPI bindings for Haskell
 description:    MPI (the [Message Passinag Interface](https://www.mpi-forum.org)) is
                 a widely used standard for distributed-memory programming on HPC
@@ -40,7 +40,7 @@ homepage:       https://github.com/eschnett/mpi-hs#readme
 bug-reports:    https://github.com/eschnett/mpi-hs/issues
 author:         Erik Schnetter <schnetter@gmail.com>
 maintainer:     Erik Schnetter <schnetter@gmail.com>, Phillip Seeber <phillip.seeber@googlemail.com>
-copyright:      2018, 2019, 2020, 2023 Erik Schnetter <schnetter@gmail.com>
+copyright:      2018, 2019, 2020, 2023, 2024 Erik Schnetter <schnetter@gmail.com>, 2024 Phillip Seeber Phillip Seeber <phillip.seeber@googlemail.com>
 license:        Apache-2.0
 license-file:   LICENSE
 build-type:     Simple

--- a/package.yaml
+++ b/package.yaml
@@ -1,10 +1,10 @@
 name: mpi-hs
-version: '0.7.3.0'
+version: '0.7.3.1'
 github: "eschnett/mpi-hs"
 license: Apache-2.0
 author: "Erik Schnetter <schnetter@gmail.com>"
 maintainer: "Erik Schnetter <schnetter@gmail.com>, Phillip Seeber <phillip.seeber@googlemail.com>"
-copyright: "2018, 2019, 2020, 2023 Erik Schnetter <schnetter@gmail.com>"
+copyright: "2018, 2019, 2020, 2023, 2024 Erik Schnetter <schnetter@gmail.com>, 2024 Phillip Seeber Phillip Seeber <phillip.seeber@googlemail.com>"
 category: Distributed Computing
 synopsis: MPI bindings for Haskell
 description: |


### PR DESCRIPTION
This adds bindings for the [MPI_Gatherv](https://docs.open-mpi.org/en/v5.0.x/man-openmpi/man3/MPI_Gatherv.3.html#mpi-gatherv) function in the low level interface. Gatherv enables gather operation with varying amounts of data from each rank.

Raises version to 0.7.3.1. This is a non-breaking change and merely an addition.